### PR TITLE
Fixes property order and uses new global settings path in v0.2.1715.0 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.1.0.{build}
+version: 1.0.0.{build}
 skip_tags: true
 pull_requests:
   do_not_increment_build_number: true

--- a/src/MSTerminalSettings.psd1
+++ b/src/MSTerminalSettings.psd1
@@ -12,6 +12,7 @@
 RootModule = 'MSTerminalSettings.psm1'
 
 # Version number of this module.
+# !!! Published version number set in appveyor.yml !!!
 ModuleVersion = '1.0.0'
 
 # Supported PSEditions


### PR DESCRIPTION
* Increment version number and add desktop to supported editions
* Deprecates -Force on Get-MSTerminalSetting
* Update for moved global settings in 0.2.1715.0
* Preserve property order when modifying the profiles.json file