### PR TITLE
Bugfix: Strip JSON Comments for WinPS

### DIFF
--- a/src/ExportedFunctions/Get-MSTerminalColorScheme.ps1
+++ b/src/ExportedFunctions/Get-MSTerminalColorScheme.ps1
@@ -4,7 +4,7 @@ function Get-MSTerminalColorScheme {
     )
     $Path = Find-MSTerminalFolder
     $SettingsPath = Join-Path $Path "profiles.json"
-    $Settings = Get-Content -Path $SettingsPath -Raw | ConvertFrom-Json
+    $Settings = ReadMSTerminalProfileJson $SettingsPath
 
     $Settings.Schemes | Where-Object {
         if($Name) {

--- a/src/ExportedFunctions/Get-MSTerminalProfile.ps1
+++ b/src/ExportedFunctions/Get-MSTerminalProfile.ps1
@@ -14,7 +14,8 @@ function Get-MSTerminalProfile {
     }
 
     $ProfilesJson = Join-Path $Path "profiles.json"
-    Get-Content -Path $ProfilesJson -Raw | ConvertFrom-Json | ForEach-Object {
+
+    ReadMSTerminalProfileJson $ProfilesJson | ForEach-Object {
         $_.Profiles
     } | Where-Object {
         $Profile = $_

--- a/src/ExportedFunctions/Get-MSTerminalSetting.ps1
+++ b/src/ExportedFunctions/Get-MSTerminalSetting.ps1
@@ -4,7 +4,7 @@ function Get-MSTerminalSetting {
     )
     $Path = Find-MSTerminalFolder
     $SettingsPath = Join-Path $Path "profiles.json"
-    $Settings = Get-Content -Path $SettingsPath -Raw | ConvertFrom-Json
+    $Settings = ReadMSTerminalProfileJson $SettingsPath
 
     if($Settings.Globals) {
         $Settings = $Settings.Globals

--- a/src/ExportedFunctions/New-MSTerminalColorScheme.ps1
+++ b/src/ExportedFunctions/New-MSTerminalColorScheme.ps1
@@ -42,7 +42,7 @@ function New-MSTerminalColorScheme {
     )
     $Path = Find-MSTerminalFolder
     $SettingsPath = Join-Path $Path "profiles.json"
-    $Settings = Get-Content -Path $SettingsPath -Raw | ConvertFrom-Json | ConvertPSObjectToHashtable
+    $Settings = ReadMSTerminalProfileJson $SettingsPath | ConvertPSObjectToHashtable
 
     if(!$Settings.Contains("schemes")) {
         $Settings["schemes"] = @()

--- a/src/ExportedFunctions/New-MSTerminalProfile.ps1
+++ b/src/ExportedFunctions/New-MSTerminalProfile.ps1
@@ -80,7 +80,7 @@ function New-MSTerminalProfile {
     )
     $Path = Find-MSTerminalFolder
     $SettingsPath = Join-Path $Path "profiles.json"
-    $Settings = Get-Content -Path $SettingsPath -Raw | ConvertFrom-Json | ConvertPSObjectToHashtable
+    $Settings = ReadMSTerminalProfileJson $SettingsPath | ConvertPSObjectToHashtable
     if($Settings.Globals) {
         $Global = $Settings["globals"]
     } else {

--- a/src/ExportedFunctions/Remove-MSTerminalColorScheme.ps1
+++ b/src/ExportedFunctions/Remove-MSTerminalColorScheme.ps1
@@ -7,7 +7,7 @@ function Remove-MSTerminalColorScheme {
     begin {
         $Path = Find-MSTerminalFolder
         $SettingsPath = Join-Path $Path "profiles.json"
-        $Settings = Get-Content -Path $SettingsPath -Raw | ConvertFrom-Json
+        $Settings = ReadMSTerminalProfileJson $SettingsPath
         $SchemesToRemove = @()
     }
     process {

--- a/src/ExportedFunctions/Remove-MSTerminalProfile.ps1
+++ b/src/ExportedFunctions/Remove-MSTerminalProfile.ps1
@@ -10,7 +10,7 @@ function Remove-MSTerminalProfile {
     begin {
         $Path = Find-MSTerminalFolder
         $SettingsPath = Join-Path $Path "profiles.json"
-        $Settings = Get-Content -Path $SettingsPath -Raw | ConvertFrom-Json
+        $Settings = ReadMSTerminalProfileJson $SettingsPath
         $ProfilesToRemove = @()
     }
     process {

--- a/src/ExportedFunctions/Set-MSTerminalProfile.ps1
+++ b/src/ExportedFunctions/Set-MSTerminalProfile.ps1
@@ -86,7 +86,7 @@ function Set-MSTerminalProfile {
         $Path = Find-MSTerminalFolder
         $SettingsPath = Join-Path $Path "profiles.json"
         # Don't use -AsHashtable for 5.1 support
-        $Settings = Get-Content -Path $SettingsPath -Raw | ConvertFrom-Json | ConvertPSObjectToHashtable
+        $Settings = ReadMSTerminalProfileJson $SettingsPath | ConvertPSObjectToHashtable
         if($Settings.Globals) {
             $Global = $Settings["globals"]
         } else {

--- a/src/ExportedFunctions/Set-MSTerminalSetting.ps1
+++ b/src/ExportedFunctions/Set-MSTerminalSetting.ps1
@@ -32,7 +32,7 @@ function Set-MSTerminalSetting {
     $Path = Find-MSTerminalFolder
     $SettingsPath = Join-Path $Path "profiles.json"
     # Don't use -AsHashtable for 5.1 support
-    $Settings = Get-Content -Path $SettingsPath -Raw | ConvertFrom-Json | ConvertPSObjectToHashtable
+    $Settings = ReadMSTerminalProfileJson $SettingsPath | ConvertPSObjectToHashtable
     if($Settings.Globals) {
         $SettingsRoot = $Settings["globals"]
     } else {

--- a/src/InternalFunctions/ReadMSTerminalProfileJson.ps1
+++ b/src/InternalFunctions/ReadMSTerminalProfileJson.ps1
@@ -1,6 +1,6 @@
 function ReadMSTerminalProfileJson ([String]$Path) {
 
-    $ProfilePath = Get-Item $Path -ErrorAction Stop
+    $ProfilesPath = Get-Item $Path -ErrorAction Stop
     $JSonCommentsRegex = '(?<!".+)//.+(?!.+")'
     $ProfilesJsonContent = Get-Content -Path $ProfilesPath -Raw
     #Powershell 5 ConvertFrom-Json can't handle single-line comments and they must be stripped

--- a/src/InternalFunctions/ReadMSTerminalProfileJson.ps1
+++ b/src/InternalFunctions/ReadMSTerminalProfileJson.ps1
@@ -1,0 +1,14 @@
+function ReadMSTerminalProfileJson ([String]$Path) {
+
+    $ProfilePath = Get-Item $Path -ErrorAction Stop
+    $JSonCommentsRegex = '(?<!".+)//.+(?!.+")'
+    $ProfilesJsonContent = Get-Content -Path $ProfilesPath -Raw
+    #Powershell 5 ConvertFrom-Json can't handle single-line comments and they must be stripped
+    if ($PSEdition -eq 'Desktop') {
+        #Match lines with // that aren't surrounded by quotes
+        $StripJsonCommentsRegex = '(?<!".+)//.+(?!.+")'
+        #Match lines with //
+        $ProfilesJsonContent = $ProfilesJsonContent -replace $StripJsonCommentsRegex
+    }
+    $ProfilesJsonContent | ConvertFrom-Json
+}

--- a/test/Get-MSTerminalProfile.Tests.ps1
+++ b/test/Get-MSTerminalProfile.Tests.ps1
@@ -40,4 +40,15 @@ Describe "Get-MSTerminalProfile" {
             }
         }
     }
+
+    Context "Default Profile" {
+        BeforeEach {
+            Copy-Item $PSScriptRoot/Profiles/NewInstallSettings.json $TestDrive/profiles.json
+        }
+
+        It "Reads the default profile without issues" {
+            $profileResult = Get-MSTerminalProfile -GUID "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}"
+            $profileResult.Name | Should -Be 'Windows Powershell'
+        }
+    }
 }

--- a/test/Profiles/NewInstallSettings.json
+++ b/test/Profiles/NewInstallSettings.json
@@ -1,0 +1,46 @@
+
+// To view the default settings, hold "alt" while clicking on the "Settings" button.
+// For documentation on these settings, see: https://aka.ms/terminal-documentation
+
+{
+    "$schema": "https://aka.ms/terminal-profiles-schema",
+
+    "defaultProfile": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+
+    "profiles":
+    [
+        {
+            // Make changes here to the powershell.exe profile
+            "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+            "name": "Windows PowerShell",
+            "commandline": "powershell.exe",
+            "hidden": false
+        },
+        {
+            // Make changes here to the cmd.exe profile
+            "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+            "name": "cmd",
+            "commandline": "cmd.exe",
+            "hidden": false
+        },
+        {
+            "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+            "hidden": false,
+            "name": "PowerShell Core",
+            "source": "Windows.Terminal.PowershellCore"
+        },
+        {
+            "guid": "{b453ae62-4e3d-5e58-b989-0a998ec441b8}",
+            "hidden": false,
+            "name": "Azure Cloud Shell",
+            "source": "Windows.Terminal.Azure"
+        }
+    ],
+
+    // Add custom color schemes to this array
+    "schemes": [],
+
+    // Add any keybinding overrides to this array.
+    // To unbind a default keybinding, set the command to "unbound"
+    "keybindings": []
+}

--- a/test/Shared.ps1
+++ b/test/Shared.ps1
@@ -6,5 +6,5 @@ $ModuleManifestPath = "$PSScriptRoot\..\Release\MSTerminalSettings\$ModuleManife
 if (!$SuppressImportModule) {
     # -Scope Global is needed when running tests from inside of psake, otherwise
     # the module's functions cannot be found in the MSTerminalSettings\ namespace
-    Import-Module $ModuleManifestPath -Scope Global -ErrorAction Stop
+    Import-Module $ModuleManifestPath -Scope Global -ErrorAction Stop -Force
 }


### PR DESCRIPTION
Moves the JSON parsing to a dedicated private function, and strips comments if run in Windows Powershell as it cannot handle single-line comments.

This is required because the new 0.5 default profile inserts single line "//" comments, and it causes get-msterminalprofile to error out if run on Windows Powershell 5.1