### PR TITLE
WIP: Added support for Windows Terminal v0.11.1121.0 or newer

### DIFF
--- a/src/ExportedFunctions/Find-MSTerminalFolder.ps1
+++ b/src/ExportedFunctions/Find-MSTerminalFolder.ps1
@@ -20,7 +20,7 @@ function Find-MSTerminalFolder {
         if($FoundPath) {
             $FoundPath
         } else {
-            Write-Error "Unable to locate Terminal profiles.json file." -ErrorAction Stop
+            Write-Error "Unable to locate Terminal $(Split-Path (DetectTerminalConfigFile) -Leaf) file." -ErrorAction Stop
         }
     }
 }

--- a/src/ExportedFunctions/Get-MSTerminalColorScheme.ps1
+++ b/src/ExportedFunctions/Get-MSTerminalColorScheme.ps1
@@ -2,8 +2,7 @@ function Get-MSTerminalColorScheme {
     param(
         $Name
     )
-    $Path = Find-MSTerminalFolder
-    $SettingsPath = Join-Path $Path "profiles.json"
+    $SettingsPath = DetectTerminalConfigFile
     $Settings = ReadMSTerminalProfileJson $SettingsPath
 
     $Settings.Schemes | Where-Object {

--- a/src/ExportedFunctions/Get-MSTerminalProfile.ps1
+++ b/src/ExportedFunctions/Get-MSTerminalProfile.ps1
@@ -13,7 +13,7 @@ function Get-MSTerminalProfile {
         return
     }
 
-    $ProfilesJson = Join-Path $Path "profiles.json"
+    $ProfilesJson = DetectTerminalConfigFile
 
     ReadMSTerminalProfileJson $ProfilesJson | ForEach-Object {
         $_.Profiles

--- a/src/ExportedFunctions/Get-MSTerminalSetting.ps1
+++ b/src/ExportedFunctions/Get-MSTerminalSetting.ps1
@@ -2,8 +2,7 @@ function Get-MSTerminalSetting {
     param(
         [Switch]$Force
     )
-    $Path = Find-MSTerminalFolder
-    $SettingsPath = Join-Path $Path "profiles.json"
+    $SettingsPath = DetectTerminalConfigFile
     $Settings = ReadMSTerminalProfileJson $SettingsPath
 
     if($Settings.Globals) {

--- a/src/ExportedFunctions/New-MSTerminalColorScheme.ps1
+++ b/src/ExportedFunctions/New-MSTerminalColorScheme.ps1
@@ -40,8 +40,7 @@ function New-MSTerminalColorScheme {
 
         [string]$yellow = "#C19C00"
     )
-    $Path = Find-MSTerminalFolder
-    $SettingsPath = Join-Path $Path "profiles.json"
+    $SettingsPath = DetectTerminalConfigFile
     $Settings = ReadMSTerminalProfileJson $SettingsPath | ConvertPSObjectToHashtable
 
     if(!$Settings.Contains("schemes")) {

--- a/src/ExportedFunctions/New-MSTerminalProfile.ps1
+++ b/src/ExportedFunctions/New-MSTerminalProfile.ps1
@@ -78,8 +78,7 @@ function New-MSTerminalProfile {
         #Arbitrary properties, no validation occurs here so use at your own risk!
         [HashTable]$ExtraSettings
     )
-    $Path = Find-MSTerminalFolder
-    $SettingsPath = Join-Path $Path "profiles.json"
+    $SettingsPath = DetectTerminalConfigFile
     $Settings = ReadMSTerminalProfileJson $SettingsPath | ConvertPSObjectToHashtable
     if($Settings.Globals) {
         $Global = $Settings["globals"]

--- a/src/ExportedFunctions/Remove-MSTerminalColorScheme.ps1
+++ b/src/ExportedFunctions/Remove-MSTerminalColorScheme.ps1
@@ -5,8 +5,7 @@ function Remove-MSTerminalColorScheme {
         [string[]]$Name
     )
     begin {
-        $Path = Find-MSTerminalFolder
-        $SettingsPath = Join-Path $Path "profiles.json"
+        $SettingsPath = DetectTerminalConfigFile
         $Settings = ReadMSTerminalProfileJson $SettingsPath
         $SchemesToRemove = @()
     }

--- a/src/ExportedFunctions/Remove-MSTerminalProfile.ps1
+++ b/src/ExportedFunctions/Remove-MSTerminalProfile.ps1
@@ -8,8 +8,7 @@ function Remove-MSTerminalProfile {
         $InputObject
     )
     begin {
-        $Path = Find-MSTerminalFolder
-        $SettingsPath = Join-Path $Path "profiles.json"
+        $SettingsPath = DetectTerminalConfigFile
         $Settings = ReadMSTerminalProfileJson $SettingsPath
         $ProfilesToRemove = @()
     }

--- a/src/ExportedFunctions/Set-MSTerminalProfile.ps1
+++ b/src/ExportedFunctions/Set-MSTerminalProfile.ps1
@@ -83,8 +83,7 @@ function Set-MSTerminalProfile {
         [hashtable]$ExtraSettings
     )
     begin {
-        $Path = Find-MSTerminalFolder
-        $SettingsPath = Join-Path $Path "profiles.json"
+        $SettingsPath = DetectTerminalConfigFile
         # Don't use -AsHashtable for 5.1 support
         $Settings = ReadMSTerminalProfileJson $SettingsPath | ConvertPSObjectToHashtable
         if($Settings.Globals) {

--- a/src/ExportedFunctions/Set-MSTerminalSetting.ps1
+++ b/src/ExportedFunctions/Set-MSTerminalSetting.ps1
@@ -29,8 +29,7 @@ function Set-MSTerminalSetting {
 
         [hashtable]$ExtraSettings = @{}
     )
-    $Path = Find-MSTerminalFolder
-    $SettingsPath = Join-Path $Path "profiles.json"
+    $SettingsPath = DetectTerminalConfigFile
     # Don't use -AsHashtable for 5.1 support
     $Settings = ReadMSTerminalProfileJson $SettingsPath | ConvertPSObjectToHashtable
     if($Settings.Globals) {

--- a/src/InternalFunctions/DetectTerminalConfigFile.ps1
+++ b/src/InternalFunctions/DetectTerminalConfigFile.ps1
@@ -1,0 +1,21 @@
+<#
+.SYNOPSIS
+This command will return the path to the right configuration file for Windows Terminal.
+.NOTES
+In version 0.11.1121.0 the configuration file for Windows Terminal (`profiles.json`) has been renamed to `settings.json`.
+#>
+function DetectTerminalConfigFile {
+    try {
+        $TerminalApp = Get-AppxPackage -Name Microsoft.WindowsTerminal
+    } catch {
+        throw "This only works if Windows Terminal is installed on this computer."
+    }
+    $Path = Find-MSTerminalFolder
+    if ($TerminalApp.Version -ge 0.11.1121.0) {
+        $SettingsPath = Join-Path $Path "settings.json"
+    } else {
+        $SettingsPath = Join-Path $Path "profiles.json"
+    }
+
+    return $SettingsPath
+}


### PR DESCRIPTION
In version 0.11.1121.0 of Windows Terminal the `profiles.json` has been renamed to `settings.json` (See [microsoft/terminal Release notes](https://github.com/microsoft/terminal/releases/tag/v0.11.1121.0)).  
  
To support this change and also to support older releases, I've added a internal function which determines the configuration file path for Windows Terminal.